### PR TITLE
Upgrade @aantron/repromise to reason-promise

### DIFF
--- a/assets/bsconfig.json
+++ b/assets/bsconfig.json
@@ -17,7 +17,7 @@
     "reason-react",
     "bucklescript-phx",
     "@glennsl/bs-json",
-    "@aantron/repromise",
+    "reason-promise",
     "bs-css"
   ],
   "refmt": 3,

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -2,11 +2,6 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
-    "@aantron/repromise": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@aantron/repromise/-/repromise-0.6.0.tgz",
-      "integrity": "sha512-nxNUWKQQhRJKmsExKi2qyZUryvpEz07H17fEhRaZC3wXkxCtjcdx9j5LMnV0+anbU+EyG/X+UnfATReerBZgMA=="
-    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -2282,9 +2277,9 @@
       }
     },
     "bs-platform": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-4.0.18.tgz",
-      "integrity": "sha512-BwzW0iYHvREqUZIgQxJmdJrxexppLvJxYQ4LLexbhCp7uZU5DIZ5ub4ZHpkCkc8fn8bsXWc+Rrejb3csi+BoAQ=="
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-7.1.0.tgz",
+      "integrity": "sha512-XUeZf1nGzmsVymG89j5L8G9YNDHl0J/5iDGExXA7a4RKxnbvP2TselBZAzFeEH4rs3gG01b7yKt+h2pm7yh7Ww=="
     },
     "bucklescript-phx": {
       "version": "0.1.3",
@@ -4137,7 +4132,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4158,12 +4154,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4178,17 +4176,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4305,7 +4306,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4317,6 +4319,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4331,6 +4334,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4338,12 +4342,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4362,6 +4368,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4442,7 +4449,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4454,6 +4462,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4539,7 +4548,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4575,6 +4585,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4594,6 +4605,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4637,12 +4649,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7791,6 +7805,11 @@
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
       }
+    },
+    "reason-promise": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/reason-promise/-/reason-promise-1.0.2.tgz",
+      "integrity": "sha512-j8DWV+71wNEKQmyW6zBOowIZq1Qec5CDWyLI37BvgOmAZgRFGFQ1MaJnbhqDe3JsYmaGyqdNMmpCJLl9EDbDAg=="
     },
     "reason-react": {
       "version": "0.5.3",

--- a/assets/package.json
+++ b/assets/package.json
@@ -9,14 +9,14 @@
     "test": "npm run build && jest lib/* --colors"
   },
   "dependencies": {
-    "@aantron/repromise": "^0.6.0",
     "@glennsl/bs-json": "^3.0.0",
     "bs-css": "^8.0.0",
-    "bs-platform": "^4.0.18",
+    "bs-platform": "^7.0.1",
     "bucklescript-phx": "^0.1.3",
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",
     "randomcolor": "^0.5.3",
+    "reason-promise": "^1.0.2",
     "reason-react": "^0.5.3"
   },
   "devDependencies": {

--- a/assets/src/App.re
+++ b/assets/src/App.re
@@ -73,7 +73,7 @@ let make = _children => {
   },
   reducer,
   didMount: self => {
-    ShopChannel.onJoin() |> Repromise.wait(joinEventHandler(self));
+    ShopChannel.onJoin()->Promise.get(joinEventHandler(self));
   },
   render: self => {
     <div className=Styles.mainContainer>

--- a/assets/src/utils/Phoenix.re
+++ b/assets/src/utils/Phoenix.re
@@ -34,8 +34,8 @@ module CreateChannel = (WS: WebSocketInterface) => {
   let sendPush = (event: string, payload: Js.t('a)): WS.Push.t =>
     WS.push(event, payload, getChannel());
 
-  let onJoin = (): Repromise.t(Belt.Result.t(InitialState.t, string)) => {
-    let (promise, resolve_promise) = Repromise.make();
+  let onJoin = (): Promise.t(Belt.Result.t(InitialState.t, string)) => {
+    let (promise, resolve_promise) = Promise.pending();
 
     getJoinEvent()
     |> WS.putReceive("ok", response =>


### PR DESCRIPTION
Repromise became [**reason-promise**](https://github.com/aantron/promise) in 1.0.0. The API was renamed (e.g., `Repromise.wait` is now `Promise.get`), rearranged to prefer `->` instead of `|>`, and helpers were added for `Result` and `Option`, as well as some miscellaneous ones. The bundle size was reduced to 1K. See the [changelog](https://github.com/aantron/promise/releases/tag/1.0.0) here; there are also two subsequent bugfix releases.

The usage of `Promise.pending` could have been replaced with [`Promise.exec`](https://github.com/aantron/promise#Creating), but I left it alone to keep the diff minimal.